### PR TITLE
Pangenome options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Options:
  
   --min-edge-cov INT   remove edges with coverage smaller than INT [0]
   --min-seq-cov  FLOAT remove sequences with coverage smaller than FLOAT [0.0]
+  --neighbour-steps  FLOAT
+                       use min-seq-cov of 1 for nodes adjacent to covered nodes [0]
+  --bub-check          add coverage to bubbles when both in and out are also covered [0]
+  --edge-to-seq        migrate edge coverage to seq coverage [0]
 
   -o FILE              write output to a file [stdout]
   -v INT               verbose level [0]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ directory to compile.
 ```
 Usage: pathfinder [options] <file>[.gfa[.gz]] [<source>[+|-] [<target>[+|-]]]
 Options:
+  -e INT               minimum L edge coverage [1]
   -c INT               minimum copy number of sequences to consider [1]
   -C INT               maximum copy number of sequences to consider [10]
+  -X INT               override the initial depth computation [0]
   -d FLOAT             prefer a circular path if length >= FLOAT * linear length [1.00]
   -p                   do graph partitioning if possible
   -a                   adjust seuqnece copy number estimation by graph structure

--- a/path.h
+++ b/path.h
@@ -95,7 +95,7 @@ void asg_print_fa(asg_t *g, FILE *fo, int line_wd);
 
 void path_destroy(path_t *path);
 void path_v_destroy(path_v *path);
-double graph_sequence_coverage_precise(asg_t *asg, double min_cf, int min_copy, int max_copy, int edge_to_seq, int bub_check, int neighbour_steps, int **copy_number);
+double graph_sequence_coverage_precise(asg_t *asg, double min_cf, int min_copy, int max_copy, int edge_to_seq, int bub_check, int neighbour_steps, int min_neighbour_len, int **copy_number);
 int adjust_sequence_copy_number_by_graph_layout(asg_t *asg, double seq_coverage, double *_adjusted_cov, int *copy_number, int max_copy, int max_round);
 kh_u32_t *sequence_duplication_by_copy_number(asg_t *asg, int *copy_number, int allow_del);
 path_t make_path_from_str(asg_t *asg, char *path_str, char *sid);

--- a/path.h
+++ b/path.h
@@ -95,7 +95,7 @@ void asg_print_fa(asg_t *g, FILE *fo, int line_wd);
 
 void path_destroy(path_t *path);
 void path_v_destroy(path_v *path);
-double graph_sequence_coverage_precise(asg_t *asg, double min_cf, int min_copy, int max_copy, int **copy_number);
+double graph_sequence_coverage_precise(asg_t *asg, double min_cf, int min_copy, int max_copy, int edge_to_seq, int bub_check, int neighbour_steps, int **copy_number);
 int adjust_sequence_copy_number_by_graph_layout(asg_t *asg, double seq_coverage, double *_adjusted_cov, int *copy_number, int max_copy, int max_round);
 kh_u32_t *sequence_duplication_by_copy_number(asg_t *asg, int *copy_number, int allow_del);
 path_t make_path_from_str(asg_t *asg, char *path_str, char *sid);

--- a/path.h
+++ b/path.h
@@ -82,7 +82,7 @@ extern "C" {
 asg_t *asg_init();
 void asg_destroy(asg_t *g);
 uint32_t asg_name2id(asg_t *g, char *name);
-asg_t *asg_read(const char *fn);
+asg_t *asg_read(const char *fn, int min_s_cov, int min_l_cov);
 asg_t *asg_make_copy(asg_t *g);
 asmg_t *asg_make_asmg_copy(asmg_t *g, asmg_t *_g);
 uint32_t asg_add_seg(asg_t *g, char *name, int allow_dups);

--- a/pathfinder.c
+++ b/pathfinder.c
@@ -224,7 +224,7 @@ static void asg_clean(asg_t *asg, uint32_t min_ec, uint32_t min_sc)
     asmg_finalize(g, 0);
 }
 
-static int pathfinder(char *asg_file, int min_copy, int max_copy, int min_edge_cov, int min_ec, double min_sc, double min_cfrac, int max_path, int do_part, int do_adjust, FILE *out_file, char *s_source, char *s_target, int VERBOSE)
+static int pathfinder(char *asg_file, int min_copy, int max_copy, int min_edge_cov, int min_ec, double min_sc, double min_cfrac, int max_path, int do_part, int do_adjust, FILE *out_file, char *s_source, char *s_target, int neighbour_steps, int bub_check, int edge_to_seq, int VERBOSE)
 {   
     asg_t *asg;
     int64_t source, target;
@@ -282,7 +282,7 @@ static int pathfinder(char *asg_file, int min_copy, int max_copy, int min_edge_c
         
         double avg_coverage, adjusted_avg_coverage;
         // initial guess of sequence copy numbers
-        avg_coverage = graph_sequence_coverage_precise(asg_copy, 0, min_copy, max_copy, &copy_number);
+        avg_coverage = graph_sequence_coverage_precise(asg_copy, 0, min_copy, max_copy, edge_to_seq, bub_check, neighbour_steps, &copy_number);
         if (VERBOSE > 1) {
             fprintf(stderr, "[M::%s] initial copy number estimation\n", __func__);
             print_copy_number(asg_copy, avg_coverage, copy_number, mstr);
@@ -383,6 +383,9 @@ static ko_longopt_t long_options[] = {
     { "seq-c-tag",      ko_required_argument, 303 },
     { "min-edge-cov",   ko_required_argument, 304 },
     { "min-seq-cov",    ko_required_argument, 305 },
+    { "neighbour-steps",ko_required_argument, 306 },
+    { "bub-check",      ko_no_argument,       307 },
+    { "edge-to-seq",    ko_no_argument,       308 },
     { "max-copy",       ko_required_argument, 'c' },
     { "max-path",       ko_required_argument, 'N' },
     { "verbose",        ko_required_argument, 'v' },
@@ -396,6 +399,7 @@ int main(int argc, char *argv[])
     const char *opt_str = "ac:d:hN:o:pv:VC:X:e:";
     ketopt_t opt = KETOPT_INIT;
     int c, min_copy, max_copy, max_path, min_ec, min_edge_cov, do_part, do_adjust, ret = 0;
+    int edge_to_seq, bub_check, neighbour_steps;
     FILE *fp_help;
     char *out_file, *ec_tag, *kc_tag, *sc_tag, *source, *target;
     double min_cfrac, min_sc;
@@ -414,6 +418,9 @@ int main(int argc, char *argv[])
     do_part = 0;
     do_adjust = 0;
     min_cfrac = 1.;
+    edge_to_seq = 0;
+    bub_check = 0;
+    neighbour_steps = 0;
     min_copy = 1;
     min_edge_cov = 1;
     max_copy = DEFAULT_MAX_COPY;
@@ -434,6 +441,9 @@ int main(int argc, char *argv[])
         else if (c == 303) sc_tag = opt.arg;
         else if (c == 304) min_ec = atoi(opt.arg);
         else if (c == 305) min_sc = atof(opt.arg);
+        else if (c == 306) neighbour_steps = atoi(opt.arg);
+        else if (c == 307) bub_check = 1;
+        else if (c == 308) edge_to_seq = 1;
         else if (c == 'v') VERBOSE = atoi(opt.arg);
         else if (c == 'h') fp_help = stdout;
         else if (c == 'V') {
@@ -469,6 +479,10 @@ int main(int argc, char *argv[])
         fprintf(fp_help, " \n");
         fprintf(fp_help, "  --min-edge-cov INT   remove edges with coverage smaller than INT [%d]\n", min_ec);
         fprintf(fp_help, "  --min-seq-cov  FLOAT remove sequences with coverage smaller than FLOAT [%.1f]\n", min_sc);
+        fprintf(fp_help, "  --neighbour-steps  FLOAT\n");
+        fprintf(fp_help, "                       use min-seq-cov of 1 for nodes adjacent to covered nodes [%d]\n", neighbour_steps);
+        fprintf(fp_help, "  --bub-check          add coverage to bubbles when both in and out are also covered [%d]\n", bub_check);
+        fprintf(fp_help, "  --edge-to-seq        migrate edge coverage to seq coverage [%d]\n", edge_to_seq);
         fprintf(fp_help, " \n");
         fprintf(fp_help, "  -o FILE              write output to a file [stdout]\n");
         fprintf(fp_help, "  -v INT               verbose level [%d]\n", VERBOSE);
@@ -527,7 +541,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    ret = pathfinder(argv[opt.ind], min_copy, max_copy, min_edge_cov, min_ec, min_sc, min_cfrac, max_path, do_part, do_adjust, stdout, source, target, VERBOSE);
+    ret = pathfinder(argv[opt.ind], min_copy, max_copy, min_edge_cov, min_ec, min_sc, min_cfrac, max_path, do_part, do_adjust, stdout, source, target, neighbour_steps, bub_check, edge_to_seq, VERBOSE);
     
     if (ret) {
         fprintf(stderr, "[E::%s] failed to analysis the GFA file\n", __func__);


### PR DESCRIPTION
There are a couple main changes here.

- The -c0 option helps with pangenomes where coverage may be zero legitimately, but the code was still setting cov to 1 in the parsing code.  The -c0 vs -c1 now also governs the gfa_parse_S function.
- Added a -e0 option to adjust the minimum edge coverage as set in the gfa_parse_L function, analogous to the change above.  This isn't the same as --min-edge-cov as that is removing edges rather than changing their coverage stats.
- Add a -X depth option to override the automatically computed depth for coverage=1.  This can be useful for when we get wildly varying depth stats due to duplicated kmers and fluctuating depth coming from nodes with no or minimal (accidental) coverage.

The above were my initial changes, that I had in place prior to your own -c0 and zero-depth edge code.

Subsequentially I also added extra options to try and "rescue" truncated paths.  "-c0" is good for accuracy, but it leaves many pangenome paths in fragments and pathfinder is skipping other groups of nodes due to lack of connectivity.  These options aim to try and resuce some of that.

- --edge-to-seq uses edge coverage data to rescue node coverage.  If we have apparent edges, but even so the node was given depth 0, then we increase it to depth 1.  It may still not be needed, but low coverage data doesn't mean it's unused, but perhaps just a bit of a distance match.
- --bub-check looks for trivial bubbles A->{P,Q}->B where A and B have coverage but P and Q do not.  In this scenario, we also ensure P and Q have coverage.  Note if one of P or Q does have coverage then this doesn't apply as we don't need to improve connectivity when it exists. 
- --neighbour-steps N is a more aggressive step that sets the minimum coverage to 1 for any node within N steps away of another node with coverage > 0.  It's therefore somewhere between -c1 and -c0 for behaviour.  We don't include the entire graph as it previously did with -c1, but we do permit linking across from nearby nodes.

These aren't very nuanced and clearly it needs a much better graph-aware strategy that looks at disconnected components and works out what potential routes we need to assess to connect them.  However pragmatically this is a middle ground that grants most of easy wins while not just falling back to the old -c1 behaviour.

Some benchmarks on 200bp reads with complex graphs (~100-200 nodes):

```
mg 9622.74   10121.7   78.1937   75.1077  10.91      1.10      0.06   98.7875    
c1 9622.74   9244.02   66.8959   72.0232   9.32      1.01      0.05   98.7908    
c0 9622.74   4026.98   38.5486   91.6411   3.1       0.49      0.04   98.5918    
bs 9622.74   6832.01   61.8254   88.1994   5.11      1.23      0.18   98.509     
EN 9622.74   9244.02   66.8959   72.0232   9.32      1.01      0.05   98.7908    
N2 9622.74   10146.2   80.5108   77.4932   9.39      1.61      0.13   98.6711 << 
n2 9622.74   10080.8   80.0327   77.614    9.34      1.56      0.14   98.6176 << 
```

mg = minigraph.  Everything else is my `kmer2node4 -k75,35,15 -U` tool.  I used the "n2" pathfinder options for processing the minigraph output.

Pathfinder options:
```
n2=-X40 -c0 --bub-check --neighbour-steps 1 --edge-to-seq                        
N2=-X40 -c0 --bub-check --neighbour-steps 1                                      
EN=-X40 -c0             --neighbour-steps 1 --edge-to-seq                        
bs=-X40 -c0 --bub-check                     --edge-to-seq                        
c0=-X40 -c0                                                                      
c1=-X40 -c1                                                                      
```

Columns are target-length (true sequence) and query-length (pathfinder derived candidate sequence), covered % (how much of true sequence is matched by the query) and used% (how much the query sequence matches the true), the number of breaks when aligning query vs target (0 being no-break), the number of >=10bp indels within sequence (so not causing a break, but are essentially a mini-break in their own right), the number of sections of 30% divergence within 100bp, and the total percentage identity of aligned fragments.

These are deliberately simulated as hard problems, so I'm pleased we're getting to the approx 80% mark and it's also pleasing on short read data to see a simple kmer mapping strategy can still outcompete minigraph.   However my 2Kbp fragment results look almost identical to the 200bp fragment ones (kmer2node, but NOT for minigraph which considerably improves) so clearly there is missing path information - either kmer depths or edges - that I'm not yet exploting.