### PR TITLE
Fix avg_cov calculation.

### DIFF
--- a/path.c
+++ b/path.c
@@ -559,6 +559,7 @@ double graph_sequence_coverage_precise(asg_t *asg, double min_cf, int min_copy, 
         new_avg_cov = MAX(new_avg_cov, min_avg_cov);
         if (fabs(new_avg_cov - avg_cov) < FLT_EPSILON) 
             break; // converged
+        avg_cov = new_avg_cov;
         if (avg_cov < global_avg_cov)
             avg_cov = global_avg_cov;
         for (i = 0; i < n_seg; ++i) {


### PR DESCRIPTION
Commit c674a694ce3da4c04b1d19ffaa4bba5acfc8e07a removed a line setting avg_cov. I believe this was an error.  The intention of this commit was to add new command line arguments, not to change any default behaviour.

The effect was noticable on the last 3 files in the TEST directory. Apologies for not spotting this change in behaviour.